### PR TITLE
Prevent `softpack-core --help` hanging forever

### DIFF
--- a/softpack_core/app.py
+++ b/softpack_core/app.py
@@ -6,7 +6,7 @@ LICENSE file in the root directory of this source tree.
 
 from datetime import datetime
 from pathlib import Path
-from typing import Any
+from typing import Any, NoReturn
 
 import typer
 from fastapi import FastAPI
@@ -107,25 +107,18 @@ class Application:
         )
         return str(url)
 
-    def main(self, package_update_interval: float) -> Any:
+    def main(self, package_update_interval: float) -> NoReturn:
         """Main command line entrypoint.
 
         Args:
             package_update_interval: interval between updates of the spack
         package list. Setting 0 disables the automatic updating.
-
-        Returns:
-            Any: The return value from running Typer commands.
         """
         if package_update_interval > 0:
             self.spack.keep_packages_updated(package_update_interval)
 
-        ret = self.commands()
-
-        if package_update_interval > 0:
-            self.spack.stop_package_timer()
-
-        return ret
+        self.commands()
+        assert False  # self.commands() does not return
 
 
 app = Application()

--- a/softpack_core/spack.py
+++ b/softpack_core/spack.py
@@ -125,6 +125,7 @@ class Spack:
         self.timer = threading.Timer(
             interval, self.keep_packages_updated, [interval]
         )
+        self.timer.daemon = True
         self.timer.start()
 
     def stop_package_timer(self) -> None:


### PR DESCRIPTION
The package list retrieval thread would previously run forever and prevent the interpreter from shutting down. This PR marks that thread as a daemon thread, so the interpreter will abruptly terminate it whenever the rest of the application exits (since all that thread does is "`git clone` into a temporary directory" and "run `spack list`", that's fine).

There was code in `Application.main` that was intended to prevent this from happening (by cancelling the thread once `self.commands()` returns), but Typer uses Click in "standalone mode" which means that `self.commands()` _doesn't_ return, it just exits. So the main thread would exit, and the entire application would then wait for the package list retrieval thread to exit, but with no main thread to tell it to exit, it would run forever.