### PR TITLE
Fix clone integration test on macOS

### DIFF
--- a/tests/integration/test_artifacts.py
+++ b/tests/integration/test_artifacts.py
@@ -28,7 +28,8 @@ def test_clone() -> None:
     ad = new_test_artifacts()
     artifacts: Artifacts = ad["artifacts"]
     path = artifacts.repo.path
-    assert path.startswith(ad["temp_dir"].name)
+    tdir = str(Path(ad["temp_dir"].name).resolve())
+    assert path.startswith(tdir)
 
     shutil.rmtree(ad["temp_dir"].name)
     assert os.path.isdir(path) is False


### PR DESCRIPTION
On machines where $TMPDIR is a symlink (e.g. macOS, where $TMPDIR is `/var/folders/...` but `/var` is a symlink to `private/var`), this test would incorrectly fail. Resolving the temporary directory's path avoids this.