### PR TITLE
Disallow spaces and other troublesome characters in environment names

### DIFF
--- a/softpack_core/artifacts.py
+++ b/softpack_core/artifacts.py
@@ -53,6 +53,7 @@ class State(Enum):
 
     ready = 'ready'
     queued = 'queued'
+    failed = 'failed'
 
 
 class Artifacts:
@@ -60,6 +61,7 @@ class Artifacts:
 
     environments_root = "environments"
     environments_file = "softpack.yml"
+    builder_out = "builder.out"
     module_file = "module"
     readme_file = "README.md"
     built_by_softpack_file = ".built_by_softpack"
@@ -131,6 +133,8 @@ class Artifacts:
 
             if Artifacts.module_file in self.obj:
                 info["state"] = State.ready
+            elif Artifacts.builder_out in self.obj:
+                info["state"] = State.failed
             else:
                 info["state"] = State.queued
 

--- a/softpack_core/schemas/environment.py
+++ b/softpack_core/schemas/environment.py
@@ -146,14 +146,20 @@ class EnvironmentInput:
     description: str
     packages: list[PackageInput]
 
-    def validate(cls) -> Union[None, InvalidInputError]:
-        """Validate that all values have been supplied.
+    def validate(self) -> Union[None, InvalidInputError]:
+        """Validate all values.
+
+        Checks that name has no spaces.
+        Checks all values have been supplied.
 
         Returns:
             None if good, or InvalidInputError if not all values supplied.
         """
-        if any(len(value) == 0 for value in vars(cls).values()):
+        if any(len(value) == 0 for value in vars(self).values()):
             return InvalidInputError(message="all fields must be filled in")
+
+        if " " in self.name:
+            return InvalidInputError(message="name must not contain spaces")
 
         return None
 
@@ -239,9 +245,9 @@ class Environment:
         Returns:
             A message confirming the success or failure of the operation.
         """
-        result = env.validate()
-        if result is not None:
-            return result
+        input_err = env.validate()
+        if input_err is not None:
+            return input_err
 
         name = env.name
         version = 1

--- a/softpack_core/schemas/environment.py
+++ b/softpack_core/schemas/environment.py
@@ -5,6 +5,7 @@ LICENSE file in the root directory of this source tree.
 """
 
 import io
+import re
 from dataclasses import dataclass
 from pathlib import Path
 from traceback import format_exception_only
@@ -158,8 +159,11 @@ class EnvironmentInput:
         if any(len(value) == 0 for value in vars(self).values()):
             return InvalidInputError(message="all fields must be filled in")
 
-        if " " in self.name:
-            return InvalidInputError(message="name must not contain spaces")
+        if not re.fullmatch(r"^[a-zA-Z0-9_-]+$", self.name):
+            return InvalidInputError(
+                message="name must only contain alphanumerics, "
+                "dash, and underscore"
+            )
 
         return None
 

--- a/softpack_core/schemas/environment.py
+++ b/softpack_core/schemas/environment.py
@@ -150,8 +150,8 @@ class EnvironmentInput:
     def validate(self) -> Union[None, InvalidInputError]:
         """Validate all values.
 
-        Checks that name has no spaces.
         Checks all values have been supplied.
+        Checks that name consists only of alphanumerics, dash, and underscore.
 
         Returns:
             None if good, or InvalidInputError if not all values supplied.

--- a/tests/integration/test_environment.py
+++ b/tests/integration/test_environment.py
@@ -106,6 +106,20 @@ def test_create_name_spaces_disallowed(httpx_post, testable_env_input):
     assert isinstance(result, InvalidInputError)
 
 
+def test_create_name_slashes_disallowed(httpx_post, testable_env_input):
+    testable_env_input.name = "names/cannot/have/slashes"
+    result = Environment.create(testable_env_input)
+    assert isinstance(result, InvalidInputError)
+
+
+def test_create_name_dashes_and_number_first_allowed(
+    httpx_post, testable_env_input
+):
+    testable_env_input.name = "7-zip_piz-7"
+    result = Environment.create(testable_env_input)
+    assert isinstance(result, CreateEnvironmentSuccess)
+
+
 def test_create_path_invalid_disallowed(httpx_post, testable_env_input):
     testable_env_input.path = "invalid/path"
     result = Environment.create(testable_env_input)

--- a/tests/integration/test_environment.py
+++ b/tests/integration/test_environment.py
@@ -93,12 +93,20 @@ def test_create(httpx_post, testable_env_input: EnvironmentInput) -> None:
     )
     assert file_in_remote(path)
 
-    orig_name = testable_env_input.name
+
+def test_create_name_empty_disallowed(httpx_post, testable_env_input):
     testable_env_input.name = ""
     result = Environment.create(testable_env_input)
     assert isinstance(result, InvalidInputError)
 
-    testable_env_input.name = orig_name
+
+def test_create_name_spaces_disallowed(httpx_post, testable_env_input):
+    testable_env_input.name = "names cannot have spaces"
+    result = Environment.create(testable_env_input)
+    assert isinstance(result, InvalidInputError)
+
+
+def test_create_path_invalid_disallowed(httpx_post, testable_env_input):
     testable_env_input.path = "invalid/path"
     result = Environment.create(testable_env_input)
     assert isinstance(result, InvalidInputError)

--- a/tests/integration/test_environment.py
+++ b/tests/integration/test_environment.py
@@ -234,6 +234,21 @@ async def test_states(httpx_post, testable_env_input):
     assert env.state == State.queued
 
     upload = UploadFile(
+        filename=Artifacts.builder_out, file=io.BytesIO(b"some output")
+    )
+
+    result = await Environment.write_artifact(
+        file=upload,
+        folder_path=f"{testable_env_input.path}/{testable_env_input.name}-1",
+        file_name=upload.filename,
+    )
+    assert isinstance(result, WriteArtifactSuccess)
+
+    env = get_env_from_iter(testable_env_input.name + "-1")
+    assert env is not None
+    assert env.state == State.failed
+
+    upload = UploadFile(
         filename=Artifacts.module_file, file=io.BytesIO(b"#%Module")
     )
 


### PR DESCRIPTION
(and also actually mark failed environments – those with builder output but no module file – as failed)