### PR TITLE
Clean up environments that couldn't be scheduled

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -49,6 +49,7 @@ jobs:
 
       - name: Install system libraries
         run: |
+          sudo apt-get update
           sudo apt-get install -y libldap2-dev libsasl2-dev libssl-dev python-dev
 
       - name: Install dependencies

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -28,6 +28,7 @@ jobs:
 
       - name: Install system libraries
         run: |
+          sudo apt-get update
           sudo apt-get install -y libldap2-dev libsasl2-dev libssl-dev python-dev
 
       - name: Install dependencies

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,6 +41,7 @@ jobs:
 
       - name: Install system libraries
         run: |
+          sudo apt-get update
           sudo apt-get install -y libldap2-dev libsasl2-dev libssl-dev python-dev
 
       - name: Install dependencies

--- a/softpack_core/artifacts.py
+++ b/softpack_core/artifacts.py
@@ -335,6 +335,9 @@ class Artifacts:
             tree_oid: the oid of the tree object that will be committed. The
             tree this refers to will replace the entire contents of the repo.
             message: the commit message
+
+        Returns:
+            pygit2.Oid: the ID of the new commit
         """
         ref = self.repo.head.name
         parents = [self.repo.lookup_reference(ref).target]

--- a/softpack_core/schemas/environment.py
+++ b/softpack_core/schemas/environment.py
@@ -59,8 +59,6 @@ class DeleteEnvironmentSuccess(Success):
 class WriteArtifactSuccess(Success):
     """Artifact successfully created."""
 
-    commit_oid: str
-
 
 # Error types
 @strawberry.type
@@ -294,6 +292,7 @@ class Environment:
             )
             r.raise_for_status()
         except Exception as e:
+            # TODO: clean up scheduled build in repo
             return BuilderError(
                 message="Connection to builder failed: "
                 + "".join(format_exception_only(type(e), e))
@@ -575,12 +574,9 @@ class Environment:
             tree_oid = cls.artifacts.create_files(
                 Path(folder_path), new_files, overwrite=True
             )
-            commit_oid = cls.artifacts.commit_and_push(
-                tree_oid, "write artifact"
-            )
+            cls.artifacts.commit_and_push(tree_oid, "write artifact")
             return WriteArtifactSuccess(
                 message="Successfully written artifact(s)",
-                commit_oid=str(commit_oid),
             )
 
         except Exception as e:

--- a/softpack_core/schemas/package_collection.py
+++ b/softpack_core/schemas/package_collection.py
@@ -6,7 +6,6 @@ LICENSE file in the root directory of this source tree.
 
 from dataclasses import dataclass
 from typing import Iterable
-from uuid import UUID
 
 import strawberry
 
@@ -23,7 +22,6 @@ class PackageMultiVersion(Package):
 class PackageCollection:
     """A Strawberry model representing a package collection."""
 
-    id: UUID
     name: str
     packages: list[PackageMultiVersion]
 

--- a/tests/integration/test_environment.py
+++ b/tests/integration/test_environment.py
@@ -15,6 +15,7 @@ from fastapi import UploadFile
 
 from softpack_core.artifacts import Artifacts, app
 from softpack_core.schemas.environment import (
+    BuilderError,
     CreateEnvironmentSuccess,
     DeleteEnvironmentSuccess,
     Environment,
@@ -26,7 +27,6 @@ from softpack_core.schemas.environment import (
     State,
     UpdateEnvironmentSuccess,
     WriteArtifactSuccess,
-    BuilderError,
 )
 from tests.integration.utils import file_in_remote
 
@@ -127,7 +127,9 @@ def test_create_path_invalid_disallowed(httpx_post, testable_env_input):
     assert isinstance(result, InvalidInputError)
 
 
-def test_create_cleans_up_after_builder_failure(httpx_post, testable_env_input):
+def test_create_cleans_up_after_builder_failure(
+    httpx_post, testable_env_input
+):
     httpx_post.side_effect = Exception('could not contact builder')
     result = Environment.create(testable_env_input)
     assert isinstance(result, BuilderError)

--- a/tests/integration/test_environment.py
+++ b/tests/integration/test_environment.py
@@ -26,6 +26,7 @@ from softpack_core.schemas.environment import (
     State,
     UpdateEnvironmentSuccess,
     WriteArtifactSuccess,
+    BuilderError,
 )
 from tests.integration.utils import file_in_remote
 
@@ -124,6 +125,22 @@ def test_create_path_invalid_disallowed(httpx_post, testable_env_input):
     testable_env_input.path = "invalid/path"
     result = Environment.create(testable_env_input)
     assert isinstance(result, InvalidInputError)
+
+
+def test_create_cleans_up_after_builder_failure(httpx_post, testable_env_input):
+    httpx_post.side_effect = Exception('could not contact builder')
+    result = Environment.create(testable_env_input)
+    assert isinstance(result, BuilderError)
+
+    dir = Path(
+        Environment.artifacts.environments_root,
+        testable_env_input.path,
+        testable_env_input.name + "-1",
+    )
+    builtPath = dir / Environment.artifacts.built_by_softpack_file
+    ymlPath = dir / Environment.artifacts.environments_file
+    assert not file_in_remote(builtPath)
+    assert not file_in_remote(ymlPath)
 
 
 def builder_called_correctly(


### PR DESCRIPTION
After https://github.com/wtsi-hgi/softpack-web/pull/55, nothing will use `id`, and it's badly-named (or at least underdocumented) and doesn't seem useful, so let's remove it.

Additionally, environments whose build could not be scheduled (the builder wasn't available, or returned an error) are now cleaned up.

Lastly, add a test to prove to ourselves that there's no (or a very low) chance of a race condition when making multiple commits simultaneously. (And even when adding a random delay in the middle of `commit_and_push` to make a race condition more likely, pygit2 caught the problem and raised an exception.)