### PR TITLE
Use current time as commit timestamp

### DIFF
--- a/softpack_core/artifacts.py
+++ b/softpack_core/artifacts.py
@@ -71,7 +71,6 @@ class Artifacts:
     users_folder_name = "users"
     groups_folder_name = "groups"
     credentials_callback = None
-    signature = None
 
     @dataclass
     class Object:
@@ -204,7 +203,11 @@ class Artifacts:
             ]
         )
 
-        self.signature = pygit2.Signature(
+    @property
+    def signature(self) -> pygit2.Signature:
+        """Get current pygit2 commit signature: author/committer/timestamp."""
+        # creating one of these implicitly looks up the current time.
+        return pygit2.Signature(
             self.settings.artifacts.repo.author,
             self.settings.artifacts.repo.email,
         )

--- a/tests/integration/test_artifacts.py
+++ b/tests/integration/test_artifacts.py
@@ -6,8 +6,8 @@ LICENSE file in the root directory of this source tree.
 
 import os
 import shutil
-import time
 import threading
+import time
 from pathlib import Path
 
 import pygit2
@@ -79,7 +79,10 @@ def test_commit_and_push() -> None:
 
     newer_commit_oid = artifacts.commit_and_push(new_tree, "new timestamp")
 
-    assert artifacts.repo.get(new_commit_oid).commit_time != artifacts.repo.get(newer_commit_oid).commit_time
+    assert (
+        artifacts.repo.get(new_commit_oid).commit_time
+        != artifacts.repo.get(newer_commit_oid).commit_time
+    )
 
 
 def add_test_file_to_repo(artifacts: Artifacts) -> tuple[pygit2.Oid, Path]:

--- a/tests/integration/test_artifacts.py
+++ b/tests/integration/test_artifacts.py
@@ -6,6 +6,7 @@ LICENSE file in the root directory of this source tree.
 
 import os
 import shutil
+import time
 import threading
 from pathlib import Path
 
@@ -73,6 +74,12 @@ def test_commit_and_push() -> None:
     assert new_commit_oid == repo_head
 
     assert file_in_remote(file_path)
+
+    time.sleep(1)
+
+    newer_commit_oid = artifacts.commit_and_push(new_tree, "new timestamp")
+
+    assert artifacts.repo.get(new_commit_oid).commit_time != artifacts.repo.get(newer_commit_oid).commit_time
 
 
 def add_test_file_to_repo(artifacts: Artifacts) -> tuple[pygit2.Oid, Path]:

--- a/tests/integration/test_environment.py
+++ b/tests/integration/test_environment.py
@@ -34,7 +34,9 @@ pytestmark = pytest.mark.repo
 
 
 def test_create(httpx_post, testable_env_input: EnvironmentInput) -> None:
+    orig_input_name = testable_env_input.name
     result = Environment.create(testable_env_input)
+    testable_env_input.name = orig_input_name
     assert isinstance(result, CreateEnvironmentSuccess)
     httpx_post.assert_called_once()
     builder_called_correctly(httpx_post, testable_env_input)
@@ -84,6 +86,7 @@ def test_create(httpx_post, testable_env_input: EnvironmentInput) -> None:
     assert yaml.safe_load(ymlFile.data.decode()) == expected_yaml
 
     result = Environment.create(testable_env_input)
+    testable_env_input.name = orig_input_name
     assert isinstance(result, CreateEnvironmentSuccess)
 
     path = Path(
@@ -137,7 +140,7 @@ def test_create_cleans_up_after_builder_failure(
     dir = Path(
         Environment.artifacts.environments_root,
         testable_env_input.path,
-        testable_env_input.name + "-1",
+        testable_env_input.name,
     )
     builtPath = dir / Environment.artifacts.built_by_softpack_file
     ymlPath = dir / Environment.artifacts.environments_file
@@ -183,13 +186,13 @@ def test_delete(httpx_post, testable_env_input) -> None:
     path = Path(
         Environment.artifacts.environments_root,
         testable_env_input.path,
-        testable_env_input.name + "-1",
+        testable_env_input.name,
         Artifacts.built_by_softpack_file,
     )
     assert file_in_remote(path)
 
     result = Environment.delete(
-        testable_env_input.name + "-1", testable_env_input.path
+        testable_env_input.name, testable_env_input.path
     )
     assert isinstance(result, DeleteEnvironmentSuccess)
 
@@ -207,7 +210,9 @@ async def test_write_artifact(httpx_post, testable_env_input):
     )
     assert isinstance(result, InvalidInputError)
 
+    orig_name = testable_env_input.name
     result = Environment.create(testable_env_input)
+    testable_env_input.name = orig_name
     assert isinstance(result, CreateEnvironmentSuccess)
     httpx_post.assert_called_once()
 
@@ -241,7 +246,9 @@ def test_iter(testable_env_input):
 
 @pytest.mark.asyncio
 async def test_states(httpx_post, testable_env_input):
+    orig_name = testable_env_input.name
     result = Environment.create(testable_env_input)
+    testable_env_input.name = orig_name
     assert isinstance(result, CreateEnvironmentSuccess)
     httpx_post.assert_called_once()
 

--- a/tox.ini
+++ b/tox.ini
@@ -88,7 +88,7 @@ allowlist_externals =
     mypy
 commands =
     flake8 softpack_core
-    flake8 tests --ignore=D101,D102,D103,D107
+    flake8 tests --ignore=D101,D102,D103,D107,E203,E266,W503
     mypy softpack_core
 
 [testenv:build]


### PR DESCRIPTION
also, fix previously-broken integration tests: `Environment.create()` now mutates its input.