### PR TITLE
Tighten GraphQL definition of environment type

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,12 @@ Run [MkDocs] server to view documentation:
 poetry run mkdocs serve
 ```
 
+To generate a GraphQL schema file:
+
+```
+poetry run strawberry export-schema softpack_core.graphql:GraphQL.schema > schema.graphql
+```
+
 
 [pip]: https://pip.pypa.io
 [Python installation guide]: http://docs.python-guide.org/en/latest/starting/installation/

--- a/softpack_core/artifacts.py
+++ b/softpack_core/artifacts.py
@@ -56,6 +56,14 @@ class State(Enum):
     failed = 'failed'
 
 
+@strawberry.enum
+class Type(Enum):
+    """Environment types."""
+
+    softpack = "softpack"
+    module = "module"
+
+
 class Artifacts:
     """Artifacts repo access class."""
 
@@ -65,9 +73,9 @@ class Artifacts:
     module_file = "module"
     readme_file = "README.md"
     built_by_softpack_file = ".built_by_softpack"
-    built_by_softpack = "softpack"
+    built_by_softpack = Type.softpack.value
     generated_from_module_file = ".generated_from_module"
-    generated_from_module = "module"
+    generated_from_module = Type.module.value
     users_folder_name = "users"
     groups_folder_name = "groups"
     credentials_callback = None

--- a/softpack_core/schemas/environment.py
+++ b/softpack_core/schemas/environment.py
@@ -19,7 +19,7 @@ from fastapi import UploadFile
 from strawberry.file_uploads import Upload
 
 from softpack_core.app import app
-from softpack_core.artifacts import Artifacts, Package, State
+from softpack_core.artifacts import Artifacts, Package, State, Type
 from softpack_core.module import GenerateEnvReadme, ToSoftpackYML
 from softpack_core.schemas.base import BaseSchema
 
@@ -196,7 +196,7 @@ class Environment:
     path: str
     description: str
     readme: str
-    type: str
+    type: Type
     packages: list[Package]
     state: Optional[State]
     artifacts = Artifacts()


### PR DESCRIPTION
This is already assumed to be the case by the frontend.

Also document how to generate a GraphQL `.schema` file, which can be used by the frontend for type-checking.