### PR TITLE
Allow dots in environment names (specifically, in version numbers).

### DIFF
--- a/softpack_core/schemas/environment.py
+++ b/softpack_core/schemas/environment.py
@@ -159,7 +159,7 @@ class EnvironmentInput:
         if any(len(value) == 0 for value in vars(self).values()):
             return InvalidInputError(message="all fields must be filled in")
 
-        if not re.fullmatch(r"^[a-zA-Z0-9_-]+$", self.name):
+        if not re.fullmatch("^[a-zA-Z0-9_-][a-zA-Z0-9_.-]*$", self.name):
             return InvalidInputError(
                 message="name must only contain alphanumerics, "
                 "dash, and underscore"

--- a/tests/integration/test_environment.py
+++ b/tests/integration/test_environment.py
@@ -493,3 +493,21 @@ async def test_create_from_module(httpx_post, testable_env_input):
         environment_path="users/non/existant",
     )
     assert isinstance(result, EnvironmentNotFoundError)
+
+def test_environmentinput_from_path():
+    for path in (
+        "users/any1/envName",
+        "users/any1/envName-1",
+        "users/any1/envName-1.1",
+        "users/any1/env_name",
+        "groups/some1/env_name-0.1.2.3",
+    ):
+        assert EnvironmentInput.from_path(path).validate() is None
+
+    for path in [
+        "users/any1/.envName",
+        "users/any1/envName!",
+        "users/any1/..envName-1",
+        "users/any1/../envName-1.1",
+    ]:
+        assert EnvironmentInput.from_path(path).validate() is not None


### PR DESCRIPTION
Modified the name validation regexp to allow dots after the first character (to prevent hidden files, and parent directory refs).