### PR TITLE
Implement `/resend-pending-builds` endpoint

### DIFF
--- a/softpack_core/schemas/environment.py
+++ b/softpack_core/schemas/environment.py
@@ -360,7 +360,6 @@ class Environment:
 
         response = cls.submit_env_to_builder(env)
         if response is not None:
-            cls.delete(env.name, env.path)
             return response
 
         return CreateEnvironmentSuccess(

--- a/softpack_core/service.py
+++ b/softpack_core/service.py
@@ -14,6 +14,7 @@ from fastapi import APIRouter, Request, UploadFile
 from typer import Typer
 from typing_extensions import Annotated
 
+from softpack_core.artifacts import State
 from softpack_core.schemas.environment import (
     CreateEnvironmentSuccess,
     Environment,
@@ -92,3 +93,14 @@ class ServiceAPI(API):
             raise Exception(resp)
 
         return resp
+
+    @staticmethod
+    @router.post("/resend-pending-builds")
+    async def resend_pending_builds():  # type: ignore[no-untyped-def]
+        """Resubmit any pending builds to the builder."""
+        for env in Environment.iter():
+            if env.state != State.queued:
+                continue
+            Environment.submit_env_to_builder(env)
+
+        return {"message": "Successfully triggered resend"}

--- a/tests/integration/test_environment.py
+++ b/tests/integration/test_environment.py
@@ -14,7 +14,7 @@ import pytest
 import yaml
 from fastapi import UploadFile
 
-from softpack_core.artifacts import Artifacts, app
+from softpack_core.artifacts import Artifacts
 from softpack_core.schemas.environment import (
     BuilderError,
     CreateEnvironmentSuccess,
@@ -29,7 +29,7 @@ from softpack_core.schemas.environment import (
     UpdateEnvironmentSuccess,
     WriteArtifactSuccess,
 )
-from tests.integration.utils import file_in_remote
+from tests.integration.utils import builder_called_correctly, file_in_remote
 
 pytestmark = pytest.mark.repo
 
@@ -160,31 +160,6 @@ def test_create_cleans_up_after_builder_failure(
     assert not file_in_remote(ymlPath)
 
 
-def builder_called_correctly(
-    post_mock, testable_env_input: EnvironmentInput
-) -> None:
-    # TODO: don't mock this; actually have a real builder service to test with?
-    host = app.settings.builder.host
-    port = app.settings.builder.port
-    post_mock.assert_called_with(
-        f"http://{host}:{port}/environments/build",
-        json={
-            "name": f"{testable_env_input.path}/{testable_env_input.name}",
-            "version": "1",
-            "model": {
-                "description": testable_env_input.description,
-                "packages": [
-                    {
-                        "name": pkg.name,
-                        "version": pkg.version,
-                    }
-                    for pkg in testable_env_input.packages
-                ],
-            },
-        },
-    )
-
-
 def test_delete(httpx_post, testable_env_input) -> None:
     result = Environment.delete(
         testable_env_input.name, testable_env_input.path
@@ -307,8 +282,8 @@ def test_iter_no_statuses(testable_env_input, mocker):
     assert envs[0].build_start is None
     assert envs[0].build_done is None
     assert envs[0].avg_wait_secs is None
-    assert envs[0].state == State.failed
-    assert envs[1].state == State.failed
+    assert envs[0].state == State.queued
+    assert envs[1].state == State.queued
 
 
 @pytest.mark.asyncio

--- a/tests/integration/test_environment.py
+++ b/tests/integration/test_environment.py
@@ -142,7 +142,7 @@ def test_create_path_invalid_disallowed(httpx_post, testable_env_input, path):
     assert isinstance(result, InvalidInputError)
 
 
-def test_create_cleans_up_after_builder_failure(
+def test_create_does_not_clean_up_after_builder_failure(
     httpx_post, testable_env_input
 ):
     httpx_post.side_effect = Exception('could not contact builder')
@@ -156,8 +156,8 @@ def test_create_cleans_up_after_builder_failure(
     )
     builtPath = dir / Environment.artifacts.built_by_softpack_file
     ymlPath = dir / Environment.artifacts.environments_file
-    assert not file_in_remote(builtPath)
-    assert not file_in_remote(ymlPath)
+    assert file_in_remote(builtPath)
+    assert file_in_remote(ymlPath)
 
 
 def test_delete(httpx_post, testable_env_input) -> None:

--- a/tests/integration/test_resend_builds.py
+++ b/tests/integration/test_resend_builds.py
@@ -1,0 +1,46 @@
+"""Copyright (c) 2024 Genome Research Ltd.
+
+This source code is licensed under the MIT license found in the
+LICENSE file in the root directory of this source tree.
+"""
+
+
+import pytest
+from fastapi.testclient import TestClient
+
+from softpack_core.app import app
+from softpack_core.schemas.environment import (
+    CreateEnvironmentSuccess,
+    Environment,
+    EnvironmentInput,
+)
+from softpack_core.service import ServiceAPI
+from tests.integration.utils import builder_called_correctly
+
+pytestmark = pytest.mark.repo
+
+
+def test_resend_pending_builds(
+    httpx_post, testable_env_input: EnvironmentInput
+):
+    ServiceAPI.register()
+    client = TestClient(app.router)
+
+    orig_name = testable_env_input.name
+    testable_env_input.name += "-1"
+    r = Environment.create_new_env(
+        testable_env_input, Environment.artifacts.built_by_softpack_file
+    )
+    assert isinstance(r, CreateEnvironmentSuccess)
+    testable_env_input.name = orig_name
+
+    httpx_post.assert_not_called()
+
+    resp = client.post(
+        url="/resend-pending-builds",
+    )
+    assert resp.status_code == 200
+    assert resp.json().get("message") == "Successfully triggered resend"
+
+    httpx_post.assert_called_once()
+    builder_called_correctly(httpx_post, testable_env_input)

--- a/tests/integration/test_spack.py
+++ b/tests/integration/test_spack.py
@@ -45,7 +45,7 @@ def test_spack_packages():
     else:
         assert len(packages) > len(pkgs)
 
-        spack = Spack(custom_repo = app.settings.spack.repo)
+        spack = Spack(custom_repo=app.settings.spack.repo)
 
         spack.packages()
 

--- a/tests/integration/utils.py
+++ b/tests/integration/utils.py
@@ -12,6 +12,7 @@ import pygit2
 import pytest
 
 from softpack_core.artifacts import Artifacts, app
+from softpack_core.schemas.environment import EnvironmentInput
 
 artifacts_dict = dict[
     str,
@@ -199,3 +200,28 @@ def file_in_repo(
         current = current[part]
 
     return current
+
+
+def builder_called_correctly(
+    post_mock, testable_env_input: EnvironmentInput
+) -> None:
+    # TODO: don't mock this; actually have a real builder service to test with?
+    host = app.settings.builder.host
+    port = app.settings.builder.port
+    post_mock.assert_called_with(
+        f"http://{host}:{port}/environments/build",
+        json={
+            "name": f"{testable_env_input.path}/{testable_env_input.name}",
+            "version": "1",
+            "model": {
+                "description": testable_env_input.description,
+                "packages": [
+                    {
+                        "name": pkg.name,
+                        "version": pkg.version,
+                    }
+                    for pkg in testable_env_input.packages
+                ],
+            },
+        },
+    )


### PR DESCRIPTION
This endpoint finds all "pending" builds (not yet successful/failed) and resends them to the builder.

Additionally, queue environments for creation even when the builder is unavailable (because it might come back up later and ask for them).