### PR TITLE
Tagging

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -3,6 +3,12 @@ schema {
   mutation: SchemaMutation
 }
 
+union AddTagResponse = AddTagSuccess | InvalidInputError | EnvironmentNotFoundError
+
+type AddTagSuccess implements Success {
+  message: String!
+}
+
 type BuilderError implements Error {
   message: String!
 }
@@ -31,6 +37,7 @@ type Environment {
   type: Type!
   packages: [Package!]!
   state: State
+  tags: [String!]!
   requested: DateTime
   buildStart: DateTime
   buildDone: DateTime
@@ -86,6 +93,7 @@ type PackageMultiVersion {
 type SchemaMutation {
   createEnvironment(env: EnvironmentInput!): CreateResponse!
   deleteEnvironment(name: String!, path: String!): DeleteResponse!
+  addTag(name: String!, path: String!, tag: String!): AddTagResponse!
   createFromModule(file: Upload!, modulePath: String!, environmentPath: String!): CreateResponse!
   updateFromModule(file: Upload!, modulePath: String!, environmentPath: String!): UpdateResponse!
 }

--- a/schema.graphql
+++ b/schema.graphql
@@ -55,6 +55,7 @@ input EnvironmentInput {
   path: String!
   description: String!
   packages: [PackageInput!]!
+  tags: [String!] = null
 }
 
 type EnvironmentNotFoundError implements Error {

--- a/softpack_core/artifacts.py
+++ b/softpack_core/artifacts.py
@@ -13,7 +13,6 @@ from typing import Iterable, Iterator, List, Optional, Tuple, Union
 
 import pygit2
 import strawberry
-import yaml
 from box import Box
 from fastapi import UploadFile
 
@@ -340,7 +339,10 @@ class Artifacts:
             Object: an Object or None
         """
         try:
-            return self.Object(Path(path, name), self.tree(str(self.environments_folder(str(path), name))))
+            return self.Object(
+                Path(path, name),
+                self.tree(str(self.environments_folder(str(path), name))),
+            )
         except KeyError:
             return None
 

--- a/softpack_core/schemas/environment.py
+++ b/softpack_core/schemas/environment.py
@@ -554,6 +554,11 @@ class Environment:
                 "underscores, dashes, and spaces"
             )
 
+        if re.search(r"\s\s", tag) is not None:
+            return InvalidInputError(
+                message="Tags must not contain runs of multiple spaces"
+            )
+
         tree = cls.artifacts.get(Path(path), name)
         if tree is None:
             return EnvironmentNotFoundError(path=path, name=name)

--- a/softpack_core/schemas/environment.py
+++ b/softpack_core/schemas/environment.py
@@ -530,7 +530,8 @@ class Environment:
     ) -> AddTagResponse:  # type: ignore
         """Add a tag to an Environment.
 
-        Tags must be composed solely of alphanumerics and spaces.
+        Tags must be composed solely of alphanumerics, dots, underscores,
+        dashes, and spaces.
 
         Adding a tag that already exists is not an error.
 
@@ -547,9 +548,10 @@ class Environment:
         if response is not None:
             return response
 
-        if re.fullmatch(r"[a-zA-Z0-9 ]+", tag) is None:
+        if re.fullmatch(r"[a-zA-Z0-9 ._-]+", tag.strip()) is None:
             return InvalidInputError(
-                message="Tags must contain only alphanumerics and spaces"
+                message="Tags must contain only alphanumerics, dots, "
+                "underscores, dashes, and spaces"
             )
 
         tree = cls.artifacts.get(Path(path), name)

--- a/softpack_core/schemas/environment.py
+++ b/softpack_core/schemas/environment.py
@@ -589,7 +589,7 @@ class Environment:
             return AddTagSuccess(message="Tag already present")
         tags.add(tag)
 
-        metadata = yaml.dump({"tags": list(tags)})
+        metadata = yaml.dump({"tags": sorted(tags)})
         tree_oid = cls.artifacts.create_file(
             environment_path, cls.artifacts.meta_file, metadata, overwrite=True
         )

--- a/softpack_core/schemas/environment.py
+++ b/softpack_core/schemas/environment.py
@@ -809,6 +809,7 @@ class EnvironmentSchema(BaseSchema):
 
         createEnvironment: CreateResponse = Environment.create  # type: ignore
         deleteEnvironment: DeleteResponse = Environment.delete  # type: ignore
+        addTag: AddTagResponse = Environment.add_tag  # type: ignore
         # writeArtifact: WriteArtifactResponse = (  # type: ignore
         #     Environment.write_artifact
         # )

--- a/softpack_core/service.py
+++ b/softpack_core/service.py
@@ -125,4 +125,8 @@ class ServiceAPI(API):
             response.status_code = 500
             message = "Failed to trigger all resends"
 
-        return {"message": message, "successes": successes, "failures": failures}
+        return {
+            "message": message,
+            "successes": successes,
+            "failures": failures,
+        }

--- a/tests/integration/test_builderupload.py
+++ b/tests/integration/test_builderupload.py
@@ -54,5 +54,5 @@ def test_builder_upload(testable_env_input):
     tree = Environment.artifacts.get(env_parent, env_name)
     assert tree is not None
 
-    assert tree[softpackYaml].data == softpackYamlContents
-    assert tree[spackLock].data == spackLockContents
+    assert tree.get(softpackYaml).data == softpackYamlContents
+    assert tree.get(spackLock).data == spackLockContents

--- a/tests/integration/test_environment.py
+++ b/tests/integration/test_environment.py
@@ -521,6 +521,9 @@ def test_tagging(httpx_post, testable_env_input: EnvironmentInput) -> None:
     result = Environment.add_tag(name, path, tag="         ")
     assert isinstance(result, InvalidInputError)
 
+    result = Environment.add_tag(name, path, tag="foo  bar")
+    assert isinstance(result, InvalidInputError)
+
     example_env = Environment.iter()[0]
     assert len(example_env.tags) == 1
     assert example_env.tags[0] == "test"

--- a/tests/integration/test_environment.py
+++ b/tests/integration/test_environment.py
@@ -515,6 +515,12 @@ def test_tagging(httpx_post, testable_env_input: EnvironmentInput) -> None:
     result = Environment.add_tag(name, path, tag="../")
     assert isinstance(result, InvalidInputError)
 
+    result = Environment.add_tag(name, path, tag="")
+    assert isinstance(result, InvalidInputError)
+
+    result = Environment.add_tag(name, path, tag="         ")
+    assert isinstance(result, InvalidInputError)
+
     example_env = Environment.iter()[0]
     assert len(example_env.tags) == 1
     assert example_env.tags[0] == "test"

--- a/tests/integration/test_environment.py
+++ b/tests/integration/test_environment.py
@@ -513,11 +513,15 @@ def test_tagging(httpx_post, testable_env_input: EnvironmentInput) -> None:
     assert isinstance(result, AddTagSuccess)
 
     example_env = Environment.iter()[0]
-    assert list(sorted(example_env.tags)) == list(sorted(["test", "second test"]))
+    assert list(sorted(example_env.tags)) == list(
+        sorted(["test", "second test"])
+    )
 
     result = Environment.add_tag(name, path, tag="test")
     assert isinstance(result, AddTagSuccess)
     assert result.message == "Tag already present"
 
     example_env = Environment.iter()[0]
-    assert list(sorted(example_env.tags)) == list(sorted(["test", "second test"]))
+    assert list(sorted(example_env.tags)) == list(
+        sorted(["test", "second test"])
+    )

--- a/tests/integration/test_environment.py
+++ b/tests/integration/test_environment.py
@@ -545,15 +545,12 @@ def test_tagging(httpx_post, testable_env_input: EnvironmentInput) -> None:
     assert isinstance(result, AddTagSuccess)
 
     example_env = Environment.iter()[0]
-    assert list(sorted(example_env.tags)) == list(
-        sorted(["test", "second test"])
-    )
+    assert example_env.tags == ["second test", "test"]
 
     result = Environment.add_tag(name, path, tag="test")
     assert isinstance(result, AddTagSuccess)
     assert result.message == "Tag already present"
 
     example_env = Environment.iter()[0]
-    assert list(sorted(example_env.tags)) == list(
-        sorted(["test", "second test"])
-    )
+    assert example_env.tags == ["second test", "test"]
+    

--- a/tests/integration/test_environment.py
+++ b/tests/integration/test_environment.py
@@ -110,6 +110,19 @@ def test_create(httpx_post, testable_env_input: EnvironmentInput) -> None:
     assert file_in_remote(path)
 
 
+def test_create_no_tags(httpx_post, testable_env_input):
+    testable_env_input.tags = None
+    result = Environment.create(testable_env_input)
+    assert isinstance(result, CreateEnvironmentSuccess)
+
+
+def test_create_illegal_tags(httpx_post, testable_env_input):
+    for tag in ["   ", " ", " leading whitespace", "trailing whitespace "]:
+        testable_env_input.tags = [tag]
+        result = Environment.create(testable_env_input)
+        assert isinstance(result, InvalidInputError)
+
+
 def test_create_name_empty_disallowed(httpx_post, testable_env_input):
     testable_env_input.name = ""
     result = Environment.create(testable_env_input)

--- a/tests/integration/test_environment.py
+++ b/tests/integration/test_environment.py
@@ -553,4 +553,3 @@ def test_tagging(httpx_post, testable_env_input: EnvironmentInput) -> None:
 
     example_env = Environment.iter()[0]
     assert example_env.tags == ["second test", "test"]
-    

--- a/tests/integration/test_environment.py
+++ b/tests/integration/test_environment.py
@@ -52,6 +52,7 @@ def test_create(httpx_post, testable_env_input: EnvironmentInput) -> None:
                 Package(name="pkg_test2"),
                 Package(name="pkg_test3", version="3.1"),
             ],
+            tags=["foo", "foo", "bar"],
         )
     )
     assert isinstance(result, CreateEnvironmentSuccess)
@@ -71,6 +72,10 @@ def test_create(httpx_post, testable_env_input: EnvironmentInput) -> None:
         "packages": ["pkg_test"],
     }
     assert yaml.safe_load(ymlFile.data.decode()) == expected_yaml
+    meta_yml = file_in_remote(dir / Environment.artifacts.meta_file)
+    expected_meta_yml = {"tags": []}
+    actual_meta_yml = yaml.safe_load(meta_yml.data.decode())
+    assert actual_meta_yml == expected_meta_yml
 
     dir = Path(
         Environment.artifacts.environments_root,
@@ -86,6 +91,11 @@ def test_create(httpx_post, testable_env_input: EnvironmentInput) -> None:
         "packages": ["pkg_test2", "pkg_test3@3.1"],
     }
     assert yaml.safe_load(ymlFile.data.decode()) == expected_yaml
+
+    meta_yml = file_in_remote(dir / Environment.artifacts.meta_file)
+    expected_meta_yml = {"tags": ["bar", "foo"]}
+    actual_meta_yml = yaml.safe_load(meta_yml.data.decode())
+    assert actual_meta_yml == expected_meta_yml
 
     result = Environment.create(testable_env_input)
     testable_env_input.name = orig_input_name


### PR DESCRIPTION
Environments now have tags, which you can specify at build time or add afterwards via the `addTag` GraphQL mutation. These are stored in a new `meta.yml` (the idea being that `softpack.yml` should never change, but metadata like tags may be mutated over time as environments are categorised in new ways).