### PR TITLE
Add backend code to handle recipes requests from the frontend.

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,22 +202,27 @@ server:
 artifacts:
     path: Path # Path to store artefacts repo.
     repo:
-      url: AnyUrl # URL to artefacts repo.
+      url: AnyUrl             # URL to artefacts repo.
       username: Optional[str] # Username required to access artefacts repo.
-      author: str # Author name for git commits to artefacts repo.
-      email: str # Email address for author of git commits to artefacts repo.
-      reader: Optional[str] # Auth token for read access to artefacts repo.
-      writer: Optional[str] # Auth token for write access to artefacts repo.
-      branch: Optional[str] # Branch to use for artefacts repo.
+      author: str             # Author name for git commits to artefacts repo.
+      email: str              # Email address for author of git commits to artefacts repo.
+      reader: Optional[str]   # Auth token for read access to artefacts repo.
+      writer: Optional[str]   # Auth token for write access to artefacts repo.
+      branch: Optional[str]   # Branch to use for artefacts repo.
 
 spack:
-  repo: str # URL to spack recipe repo.
-  bin: str # Path to spack exectable.
+  repo: str            # URL to spack recipe repo.
+  bin: str             # Path to spack exectable.
   cache: Optional[str] # Directory to store cached spack recipe information.
 
 builder:
   host: str # URL to a GSB server
   port: int # Port of the GSB server
+
+recipes:
+  toAddr: Optional[str]   # Address to which recipe requests will be sent.
+  fromAddr: Optional[str] # Address from which recipe requests will be sent.
+  smtp: Optional[str]     # Address to an SMTP relay
 ```
 
 ## Usage

--- a/schema.graphql
+++ b/schema.graphql
@@ -39,6 +39,7 @@ type Environment {
   state: State
   tags: [String!]!
   hidden: Boolean!
+  cachedEnvs: [Environment!]!
   requested: DateTime
   buildStart: DateTime
   buildDone: DateTime
@@ -117,6 +118,7 @@ enum State {
   ready
   queued
   failed
+  waiting
 }
 
 interface Success {

--- a/scripts/recipe-requests.sh
+++ b/scripts/recipe-requests.sh
@@ -1,0 +1,90 @@
+#!/bin/bash
+
+set -euo pipefail;
+
+declare CORE_URL="http://127.0.0.1:8000";
+
+IFS=$'\n';
+
+while true; do
+	declare -a data=( $(curl "$CORE_URL/requestedRecipes" 2> /dev/null | jq -c '.[]') ) || {
+		echo "Error: failed to get data from Core." >&2;
+
+		exit 1;
+	}
+
+	if [ "${#data[@]}" -eq 0 ]; then
+		echo "No requested recipes."
+
+		exit 0;
+	fi;
+
+	declare num=0;
+
+	for recipe in "${data[@]}";do
+		let "num+=1";
+
+		echo -n "$num: ";
+		echo "$recipe" | jq "\"\(.name)@\(.version)\"" -r;
+	done;
+
+	echo "q. Quit";
+
+	read num;
+
+	if [ "$num" = "q" -o "$num" = "Q" ]; then
+		exit 0;
+	fi;
+	
+	if [ "$num" -gt 0 -a "$num" -le "${#data[@]}" ] 2> /dev/null; then
+		while true; do
+			echo "${data[$((num - 1))]}" | jq "\"\(.name)@\(.version)\\nUsername: \(.username)\\nURL: \(.url)\\nDescription: \(.description)\"" -r;
+
+			echo -e "F. Fufill Request\nR. Remove Request\nB. Back";
+
+			read v;
+
+			case "$v" in
+			"f"|"F")
+				echo -n "Enter new package name (blank to keep existing): ";
+
+				read pkgname;
+
+				echo -n "Enter new package version (blank to keep existing): ";
+
+				read pkgversion
+
+				if curl -d "$({
+					echo "${data[$((num - 1))]}" | jq '{"requestedName": .name, "requestedVersion": .version}' -c;
+					echo "${data[$((num - 1))]}" | jq '{"name","version"}' -c;
+					echo -e "$pkgname\n$pkgversion" | jq -s -R 'split("\n")[:2] | to_entries | map({(if .key == 0 then "name" else "version" end): .value}) | add | del(..|select(. == ""))' -c;
+				} | jq -s add -c)" "$CORE_URL/fulfilRequestedRecipe"; then
+					echo;
+
+					break;
+				fi;;
+			"r"|"R")
+				echo -n "Are you sure you want to remove the request $(echo "${data[$((num - 1))]}" | jq "\"\(.name)@\(.version)\"" -r)? (yN): ";
+
+				read v;
+
+				if [ "$v" = "y" -o "$v" = "Y" ]; then
+					if curl -d "$(echo "${data[$((num - 1))]}" | jq 'with_entries(select([.key] | inside(["name", "version"])))')" "$CORE_URL/removeRequestedRecipe"; then
+						echo;
+
+						break;
+					fi;
+				else
+					echo "Invalid Response.";
+				fi;;
+			"b"|"B")
+				break;;
+			*)
+				echo "Invalid Response.";;
+			esac;
+		done;
+
+	else
+		echo "Invalid Response."
+	fi;
+done;

--- a/softpack_core/config/conf/config.yml
+++ b/softpack_core/config/conf/config.yml
@@ -25,6 +25,12 @@ spack:
   repo: https://github.com/custom-spack/repo
   bin: /path/to/spack
 
+recipes:
+  toAddr: none@domain.com
+  fromAddr: none@domain.com
+  smtp: some.mail.relay
+
+
 # Vault Config
 #  vault:
 #      url:

--- a/softpack_core/config/models.py
+++ b/softpack_core/config/models.py
@@ -78,3 +78,11 @@ class SpackConfig(BaseModel):
     repo: str
     bin: str
     cache: Optional[str]
+
+
+class RecipeConfig(BaseModel):
+    """Email settings to send recipe requests to."""
+
+    toAddr: Optional[str]
+    fromAddr: Optional[str]
+    smtp: Optional[str]

--- a/softpack_core/config/settings.py
+++ b/softpack_core/config/settings.py
@@ -18,6 +18,7 @@ from .models import (
     ArtifactsConfig,
     BuilderConfig,
     LDAPConfig,
+    RecipeConfig,
     ServerConfig,
     SpackConfig,
     VaultConfig,
@@ -34,6 +35,7 @@ class Settings(BaseSettings):
     artifacts: ArtifactsConfig
     spack: SpackConfig
     builder: BuilderConfig
+    recipes: RecipeConfig
 
     class Config:
         """Configuration loader."""

--- a/softpack_core/service.py
+++ b/softpack_core/service.py
@@ -5,16 +5,19 @@ LICENSE file in the root directory of this source tree.
 """
 
 
+import smtplib
 import urllib.parse
+from email.mime.text import MIMEText
 from pathlib import Path
 
 import typer
 import uvicorn
+import yaml
 from fastapi import APIRouter, Request, Response, UploadFile
 from typer import Typer
 from typing_extensions import Annotated
 
-from softpack_core.artifacts import State, artifacts
+from softpack_core.artifacts import Artifacts, State, artifacts
 from softpack_core.schemas.environment import (
     CreateEnvironmentSuccess,
     Environment,
@@ -121,6 +124,7 @@ class ServiceAPI(API):
         for env in Environment.iter():
             if env.state != State.queued:
                 continue
+
             result = Environment.submit_env_to_builder(
                 EnvironmentInput(
                     name=env.name,
@@ -129,6 +133,7 @@ class ServiceAPI(API):
                     packages=[PackageInput(**vars(p)) for p in env.packages],
                 )
             )
+
             if result is None:
                 successes += 1
             else:
@@ -145,3 +150,172 @@ class ServiceAPI(API):
             "successes": successes,
             "failures": failures,
         }
+
+    @staticmethod
+    @router.post("/requestRecipe")
+    async def request_recipe(  # type: ignore[no-untyped-def]
+        request: Request,
+    ):
+        """Request a recipe to be created."""
+        data = await request.json()
+
+        for key in ("name", "version", "description", "url", "username"):
+            if key not in data or not isinstance(data[key], str):
+                return {"error": "Invalid Input"}
+
+        try:
+            artifacts.create_recipe_request(
+                Artifacts.RecipeObject(
+                    data["name"],
+                    data["version"],
+                    data["description"],
+                    data["url"],
+                    data["username"],
+                )
+            )
+        except Exception as e:
+            return {"error": str(e)}
+
+        recipeConfig = app.settings.recipes.dict()
+
+        if all(
+            key in recipeConfig and isinstance(recipeConfig[key], str)
+            for key in ["fromAddr", "toAddr", "smtp"]
+        ):
+            msg = MIMEText(
+                f'User: {data["username"]}\n'
+                + f'Recipe: {data["name"]}\n'
+                + f'Version: {data["version"]}\n'
+                + f'URL: {data["url"]}\n'
+                + f'Description: {data["description"]}'
+            )
+            msg["Subject"] = "SoftPack Recipe Request"
+            msg["From"] = recipeConfig["fromAddr"]
+            msg["To"] = recipeConfig["toAddr"]
+
+            s = smtplib.SMTP(recipeConfig["smtp"])
+            s.sendmail(
+                recipeConfig["fromAddr"],
+                [recipeConfig["toAddr"]],
+                msg.as_string(),
+            )
+            s.quit()
+
+        return {"message": "Request Created"}
+
+    @staticmethod
+    @router.get("/requestedRecipes")
+    async def requested_recipes(  # type: ignore[no-untyped-def]
+        request: Request,
+    ):
+        """List requested recipes."""
+        return list(artifacts.iter_recipe_requests())
+
+    @staticmethod
+    @router.post("/fulfilRequestedRecipe")
+    async def fulfil_recipe(  # type: ignore[no-untyped-def]
+        request: Request,
+    ):
+        """Fulfil a recipe request."""
+        data = await request.json()
+
+        for key in ("name", "version", "requestedName", "requestedVersion"):
+            if not isinstance(data[key], str):
+                return {"error": "Invalid Input"}
+
+        r = artifacts.get_recipe_request(
+            data["requestedName"], data["requestedVersion"]
+        )
+
+        if r is None:
+            return {"error": "Unknown Recipe"}
+
+        for env in Environment.iter():
+            if env.state != State.waiting:
+                continue
+
+            changed = False
+
+            for pkg in env.packages:
+                if (
+                    pkg.name.startswith("*")
+                    and pkg.name[1:] == data["requestedName"]
+                    and pkg.version == data["requestedVersion"]
+                ):
+                    pkg.name = data["name"]
+                    pkg.version = data["version"]
+                    changed = True
+
+                    break
+
+            if not changed:
+                continue
+
+            artifacts.commit_and_push(
+                artifacts.create_file(
+                    Path(Artifacts.environments_root, env.path, env.name),
+                    Artifacts.environments_file,
+                    yaml.dump(
+                        dict(
+                            description=env.description,
+                            packages=[
+                                pkg.name
+                                + ("@" + pkg.version if pkg.version else "")
+                                for pkg in env.packages
+                            ],
+                        )
+                    ),
+                    False,
+                    True,
+                ),
+                "fulfil recipe request for environment",
+            )
+
+            if not env.has_requested_recipes():
+                Environment.submit_env_to_builder(
+                    EnvironmentInput(
+                        name=env.name,
+                        path=env.path,
+                        description=env.description,
+                        packages=[
+                            PackageInput(**vars(p)) for p in env.packages
+                        ],
+                    )
+                )
+
+        artifacts.remove_recipe_request(
+            data["requestedName"], data["requestedVersion"]
+        )
+
+        return {"message": "Recipe Fulfilled"}
+
+    @staticmethod
+    @router.post("/removeRequestedRecipe")
+    async def remove_recipe(  # type: ignore[no-untyped-def]
+        request: Request,
+    ):
+        """Remove a recipe request."""
+        data = await request.json()
+
+        for key in ("name", "version"):
+            if not isinstance(data[key], str):
+                return {"error": "Invalid Input"}
+
+        for env in Environment.iter():
+            for pkg in env.packages:
+                if (
+                    pkg.name.startswith("*")
+                    and pkg.name[1:] == data["name"]
+                    and pkg.version == data["version"]
+                ):
+                    return {
+                        "error": "There are environments relying of this "
+                        + "requested recipe; can not delete."
+                    }
+
+        try:
+            artifacts.remove_recipe_request(data["name"], data["version"])
+        except Exception as e:
+            return {"error": e}
+
+        return {"message": "Request Removed"}

--- a/softpack_core/service.py
+++ b/softpack_core/service.py
@@ -309,7 +309,7 @@ class ServiceAPI(API):
                     and pkg.version == data["version"]
                 ):
                     return {
-                        "error": "There are environments relying of this "
+                        "error": "There are environments relying on this "
                         + "requested recipe; can not delete."
                     }
 

--- a/tests/integration/test_environment.py
+++ b/tests/integration/test_environment.py
@@ -276,6 +276,7 @@ def test_iter(testable_env_input, mocker):
         },
     ]
 
+    artifacts.updated = True
     envs = list(Environment.iter())
     assert len(envs) == 2
     assert envs[0].requested == datetime.datetime(
@@ -297,10 +298,8 @@ def test_iter(testable_env_input, mocker):
     assert envs[0].avg_wait_secs == envs[1].avg_wait_secs == 20
 
 
-def test_iter_no_statuses(testable_env_input, mocker):
-    get_mock = mocker.patch("httpx.get")
-    get_mock.return_value.json.return_value = []
-
+def test_iter_no_statuses(testable_env_input):
+    artifacts.updated = True
     envs = list(Environment.iter())
     assert len(envs) == 2
     assert envs[0].requested is None
@@ -603,3 +602,14 @@ def test_force_hidden(
     new_first = Environment.iter()[0]
 
     assert first_env.path != new_first.path or first_env.name != new_first.name
+
+
+def test_environment_with_requested_recipe(
+    httpx_post, testable_env_input: EnvironmentInput
+) -> None:
+    testable_env_input.packages[0].name = (
+        "*" + testable_env_input.packages[0].name
+    )
+    result = Environment.create(testable_env_input)
+    assert isinstance(result, CreateEnvironmentSuccess)
+    httpx_post.assert_not_called()

--- a/tests/integration/test_recipe_requests.py
+++ b/tests/integration/test_recipe_requests.py
@@ -197,6 +197,6 @@ def test_request_recipe(httpx_post, testable_env_input):
     )
 
     assert resp.json() == {
-        "error": "There are environments relying of this requested recipe; "
+        "error": "There are environments relying on this requested recipe; "
         + "can not delete."
     }

--- a/tests/integration/test_recipe_requests.py
+++ b/tests/integration/test_recipe_requests.py
@@ -1,0 +1,202 @@
+"""Copyright (c) 2024 Genome Research Ltd.
+
+This source code is licensed under the MIT license found in the
+LICENSE file in the root directory of this source tree.
+"""
+
+from fastapi.testclient import TestClient
+
+from softpack_core.app import app
+from softpack_core.schemas.environment import (
+    CreateEnvironmentSuccess,
+    Environment,
+    EnvironmentInput,
+    PackageInput,
+)
+from tests.integration.utils import builder_called_correctly
+
+
+def test_request_recipe(httpx_post, testable_env_input):
+    client = TestClient(app.router)
+    resp = client.post(
+        url="/requestRecipe",
+        json={
+            "name": "a_recipe",
+            "version": "1.2",
+            "description": "A description",
+            "url": "http://example.com",
+            "username": "me",
+        },
+    )
+
+    assert resp.json() == {"message": "Request Created"}
+
+    resp = client.get(url="/requestedRecipes")
+
+    assert resp.json() == [
+        {
+            "name": "a_recipe",
+            "version": "1.2",
+            "description": "A description",
+            "url": "http://example.com",
+            "username": "me",
+        }
+    ]
+
+    resp = client.post(
+        url="/requestRecipe",
+        json={
+            "name": "a_recipe",
+            "version": "1.2",
+            "description": "A description",
+            "url": "http://example.com",
+            "username": "me",
+        },
+    )
+
+    assert resp.json() == {"error": "File already exists"}
+
+    resp = client.post(
+        url="/requestRecipe",
+        json={
+            "nome": "a_recipe",
+            "version": "1.2",
+            "description": "A description",
+            "url": "http://example.com",
+            "username": "me",
+        },
+    )
+
+    assert resp.json() == {"error": "Invalid Input"}
+
+    resp = client.post(
+        url="/requestRecipe",
+        json={
+            "name": "b_recipe",
+            "version": "1.4",
+            "description": "Another description",
+            "url": "http://example.com",
+            "username": "me2",
+        },
+    )
+
+    assert resp.json() == {"message": "Request Created"}
+
+    resp = client.get(url="/requestedRecipes")
+
+    assert resp.json() == [
+        {
+            "name": "a_recipe",
+            "version": "1.2",
+            "description": "A description",
+            "url": "http://example.com",
+            "username": "me",
+        },
+        {
+            "name": "b_recipe",
+            "version": "1.4",
+            "description": "Another description",
+            "url": "http://example.com",
+            "username": "me2",
+        },
+    ]
+
+    env = EnvironmentInput.from_path("users/me/my_env-1")
+    env.packages = [
+        PackageInput.from_name("pkg@1"),
+        PackageInput.from_name("*a_recipe@1.2"),
+    ]
+
+    assert len(Environment.iter()) == 2
+    assert isinstance(Environment.create(env), CreateEnvironmentSuccess)
+
+    envs = Environment.iter()
+
+    assert len(envs) == 3
+    assert len(envs[0].packages) == 2
+    assert envs[0].packages[0].name == "pkg"
+    assert envs[0].packages[0].version == "1"
+    assert envs[0].packages[1].name == "*a_recipe"
+    assert envs[0].packages[1].version == "1.2"
+
+    httpx_post.assert_not_called()
+
+    resp = client.post(
+        url="/fulfilRequestedRecipe",
+        json={
+            "name": "finalRecipe",
+            "version": "1.2.1",
+            "requestedName": "a_recipe",
+            "requestedVersion": "1.2",
+        },
+    )
+
+    assert resp.json() == {"message": "Recipe Fulfilled"}
+
+    httpx_post.assert_called_once()
+
+    env.name = "my_env-1"
+    env.packages[1] = PackageInput.from_name("finalRecipe@1.2.1")
+
+    builder_called_correctly(httpx_post, env)
+
+    envs = Environment.iter()
+
+    assert len(envs) == 3
+    assert len(envs[0].packages) == 2
+    assert envs[0].packages[0].name == "pkg"
+    assert envs[0].packages[0].version == "1"
+    assert envs[0].packages[1].name == "finalRecipe"
+    assert envs[0].packages[1].version == "1.2.1"
+
+    resp = client.get(url="/requestedRecipes")
+
+    assert resp.json() == [
+        {
+            "name": "b_recipe",
+            "version": "1.4",
+            "description": "Another description",
+            "url": "http://example.com",
+            "username": "me2",
+        }
+    ]
+
+    resp = client.post(
+        url="/removeRequestedRecipe",
+        json={"name": "b_recipe", "version": "1.4"},
+    )
+
+    assert resp.json() == {"message": "Request Removed"}
+
+    resp = client.get(url="/requestedRecipes")
+
+    assert resp.json() == []
+
+    resp = client.post(
+        url="/requestRecipe",
+        json={
+            "name": "c_recipe",
+            "version": "0.9",
+            "description": "Lorem ipsum.",
+            "url": "http://example.com",
+            "username": "me",
+        },
+    )
+
+    env = EnvironmentInput.from_path("users/me/my_env-2")
+    env.packages = [
+        PackageInput.from_name("pkg@1"),
+        PackageInput.from_name("*c_recipe@0.9"),
+    ]
+
+    assert isinstance(Environment.create(env), CreateEnvironmentSuccess)
+
+    resp = client.post(
+        url="/removeRequestedRecipe",
+        json={"name": "c_recipe", "version": "0.9"},
+    )
+
+    assert resp.json() == {
+        "error": "There are environments relying of this requested recipe; "
+        + "can not delete."
+    }

--- a/tests/integration/test_spack.py
+++ b/tests/integration/test_spack.py
@@ -4,80 +4,69 @@ This source code is licensed under the MIT license found in the
 LICENSE file in the root directory of this source tree.
 """
 
-import time
 
-import pytest
-
-from softpack_core.app import app
-from softpack_core.schemas.package_collection import (
-    PackageCollection,
-    PackageMultiVersion,
-)
-from softpack_core.spack import Package, Spack
-
-
-def test_spack_packages():
-    spack = Spack()
-    spack.packages()
-
-    pkgs = spack.stored_packages
-
-    assert len(pkgs) > 1
-
-    assert isinstance(pkgs[0], Package)
-
-    assert pkgs[0].name != ""
-
-    assert len(pkgs[0].versions) > 0
-
-    assert pkgs[0].versions[0] != ""
-
-    packages = list(PackageCollection.iter())
-
-    assert isinstance(packages[0], PackageMultiVersion)
-
-    assert packages[0].name != ""
-
-    assert len(packages[0].versions) != 0
-
-    if app.settings.spack.repo == "https://github.com/custom-spack/repo":
-        assert len(packages) == len(pkgs)
-    else:
-        assert len(packages) > len(pkgs)
-
-        spack = Spack(custom_repo=app.settings.spack.repo)
-
-        spack.packages()
-
-        assert len(spack.stored_packages) == len(packages)
-
-
-def test_spack_package_updater():
-    spack = Spack()
-
-    assert len(spack.stored_packages) == 0
-
-    spack.keep_packages_updated(1)
-
-    pkgs = spack.stored_packages
-
-    assert len(pkgs) > 0
-
-    if app.settings.spack.repo == "https://github.com/custom-spack/repo":
-        pytest.skip("skipped due to missing custom repo")
-
-    spack.custom_repo = app.settings.spack.repo
-
-    timeout = time.time() + 60 * 2
-
-    while True:
-        new_pkgs = spack.stored_packages
-
-        if len(new_pkgs) > len(pkgs) or time.time() > timeout:
-            break
-
-        time.sleep(0.1)
-
-    assert len(new_pkgs) > len(pkgs)
-
-    spack.stop_package_timer()
+# def test_spack_packages():
+#    spack = Spack()
+#    spack.packages()
+#
+#    pkgs = spack.stored_packages
+#
+#    assert len(pkgs) > 1
+#
+#    assert isinstance(pkgs[0], Package)
+#
+#    assert pkgs[0].name != ""
+#
+#    assert len(pkgs[0].versions) > 0
+#
+#    assert pkgs[0].versions[0] != ""
+#
+#    packages = list(PackageCollection.iter())
+#
+#    assert isinstance(packages[0], PackageMultiVersion)
+#
+#    assert packages[0].name != ""
+#
+#    assert len(packages[0].versions) != 0
+#
+#    if app.settings.spack.repo == "https://github.com/custom-spack/repo":
+#        assert len(packages) == len(pkgs)
+#    else:
+#        assert len(packages) > len(pkgs)
+#
+#        spack = Spack(custom_repo=app.settings.spack.repo)
+#
+#        spack.packages()
+#
+#        assert len(spack.stored_packages) == len(packages)
+#
+#
+# def test_spack_package_updater():
+#    spack = Spack()
+#
+#    assert len(spack.stored_packages) == 0
+#
+#    spack.keep_packages_updated(1)
+#
+#    pkgs = spack.stored_packages
+#
+#    assert len(pkgs) > 0
+#
+#    if app.settings.spack.repo == "https://github.com/custom-spack/repo":
+#        pytest.skip("skipped due to missing custom repo")
+#
+#    spack.custom_repo = app.settings.spack.repo
+#
+#    timeout = time.time() + 60 * 2
+#
+#    while True:
+#        new_pkgs = spack.stored_packages
+#
+#        if len(new_pkgs) > len(pkgs) or time.time() > timeout:
+#            break
+#
+#        time.sleep(0.1)
+#
+#    assert len(new_pkgs) > len(pkgs)
+#
+#    spack.stop_package_timer()

--- a/tests/integration/test_spack.py
+++ b/tests/integration/test_spack.py
@@ -5,68 +5,68 @@ LICENSE file in the root directory of this source tree.
 """
 
 
-# def test_spack_packages():
-#    spack = Spack()
-#    spack.packages()
-#
-#    pkgs = spack.stored_packages
-#
-#    assert len(pkgs) > 1
-#
-#    assert isinstance(pkgs[0], Package)
-#
-#    assert pkgs[0].name != ""
-#
-#    assert len(pkgs[0].versions) > 0
-#
-#    assert pkgs[0].versions[0] != ""
-#
-#    packages = list(PackageCollection.iter())
-#
-#    assert isinstance(packages[0], PackageMultiVersion)
-#
-#    assert packages[0].name != ""
-#
-#    assert len(packages[0].versions) != 0
-#
-#    if app.settings.spack.repo == "https://github.com/custom-spack/repo":
-#        assert len(packages) == len(pkgs)
-#    else:
-#        assert len(packages) > len(pkgs)
-#
-#        spack = Spack(custom_repo=app.settings.spack.repo)
-#
-#        spack.packages()
-#
-#        assert len(spack.stored_packages) == len(packages)
-#
-#
-# def test_spack_package_updater():
-#    spack = Spack()
-#
-#    assert len(spack.stored_packages) == 0
-#
-#    spack.keep_packages_updated(1)
-#
-#    pkgs = spack.stored_packages
-#
-#    assert len(pkgs) > 0
-#
-#    if app.settings.spack.repo == "https://github.com/custom-spack/repo":
-#        pytest.skip("skipped due to missing custom repo")
-#
-#    spack.custom_repo = app.settings.spack.repo
-#
-#    timeout = time.time() + 60 * 2
-#
-#    while True:
-#        new_pkgs = spack.stored_packages
-#
-#        if len(new_pkgs) > len(pkgs) or time.time() > timeout:
-#            break
-#
-#        time.sleep(0.1)
-#
-#    assert len(new_pkgs) > len(pkgs)
-#
-#    spack.stop_package_timer()
+def test_spack_packages():
+   spack = Spack()
+   spack.packages()
+
+   pkgs = spack.stored_packages
+
+   assert len(pkgs) > 1
+
+   assert isinstance(pkgs[0], Package)
+
+   assert pkgs[0].name != ""
+
+   assert len(pkgs[0].versions) > 0
+
+   assert pkgs[0].versions[0] != ""
+
+   packages = list(PackageCollection.iter())
+
+   assert isinstance(packages[0], PackageMultiVersion)
+
+   assert packages[0].name != ""
+
+   assert len(packages[0].versions) != 0
+
+   if app.settings.spack.repo == "https://github.com/custom-spack/repo":
+       assert len(packages) == len(pkgs)
+   else:
+       assert len(packages) > len(pkgs)
+
+       spack = Spack(custom_repo=app.settings.spack.repo)
+
+       spack.packages()
+
+       assert len(spack.stored_packages) == len(packages)
+
+
+def test_spack_package_updater():
+   spack = Spack()
+
+   assert len(spack.stored_packages) == 0
+
+   spack.keep_packages_updated(1)
+
+   pkgs = spack.stored_packages
+
+   assert len(pkgs) > 0
+
+   if app.settings.spack.repo == "https://github.com/custom-spack/repo":
+       pytest.skip("skipped due to missing custom repo")
+
+   spack.custom_repo = app.settings.spack.repo
+
+   timeout = time.time() + 60 * 2
+
+   while True:
+       new_pkgs = spack.stored_packages
+
+       if len(new_pkgs) > len(pkgs) or time.time() > timeout:
+           break
+
+       time.sleep(0.1)
+
+   assert len(new_pkgs) > len(pkgs)
+
+   spack.stop_package_timer()

--- a/tests/integration/test_spack.py
+++ b/tests/integration/test_spack.py
@@ -4,69 +4,80 @@ This source code is licensed under the MIT license found in the
 LICENSE file in the root directory of this source tree.
 """
 
+import time
+
+import pytest
+
+from softpack_core.app import app
+from softpack_core.schemas.package_collection import (
+    PackageCollection,
+    PackageMultiVersion,
+)
+from softpack_core.spack import Package, Spack
+
 
 def test_spack_packages():
-   spack = Spack()
-   spack.packages()
+    spack = Spack()
+    spack.packages()
 
-   pkgs = spack.stored_packages
+    pkgs = spack.stored_packages
 
-   assert len(pkgs) > 1
+    assert len(pkgs) > 1
 
-   assert isinstance(pkgs[0], Package)
+    assert isinstance(pkgs[0], Package)
 
-   assert pkgs[0].name != ""
+    assert pkgs[0].name != ""
 
-   assert len(pkgs[0].versions) > 0
+    assert len(pkgs[0].versions) > 0
 
-   assert pkgs[0].versions[0] != ""
+    assert pkgs[0].versions[0] != ""
 
-   packages = list(PackageCollection.iter())
+    packages = list(PackageCollection.iter())
 
-   assert isinstance(packages[0], PackageMultiVersion)
+    assert isinstance(packages[0], PackageMultiVersion)
 
-   assert packages[0].name != ""
+    assert packages[0].name != ""
 
-   assert len(packages[0].versions) != 0
+    assert len(packages[0].versions) != 0
 
-   if app.settings.spack.repo == "https://github.com/custom-spack/repo":
-       assert len(packages) == len(pkgs)
-   else:
-       assert len(packages) > len(pkgs)
+    if app.settings.spack.repo == "https://github.com/custom-spack/repo":
+        assert len(packages) == len(pkgs)
+    else:
+        assert len(packages) > len(pkgs)
 
-       spack = Spack(custom_repo=app.settings.spack.repo)
+        spack = Spack(custom_repo=app.settings.spack.repo)
 
-       spack.packages()
+        spack.packages()
 
-       assert len(spack.stored_packages) == len(packages)
+        assert len(spack.stored_packages) == len(packages)
 
 
 def test_spack_package_updater():
-   spack = Spack()
+    spack = Spack()
 
-   assert len(spack.stored_packages) == 0
+    assert len(spack.stored_packages) == 0
 
-   spack.keep_packages_updated(1)
+    spack.keep_packages_updated(1)
 
-   pkgs = spack.stored_packages
+    pkgs = spack.stored_packages
 
-   assert len(pkgs) > 0
+    assert len(pkgs) > 0
 
-   if app.settings.spack.repo == "https://github.com/custom-spack/repo":
-       pytest.skip("skipped due to missing custom repo")
+    if app.settings.spack.repo == "https://github.com/custom-spack/repo":
+        pytest.skip("skipped due to missing custom repo")
 
-   spack.custom_repo = app.settings.spack.repo
+    spack.custom_repo = app.settings.spack.repo
 
-   timeout = time.time() + 60 * 2
+    timeout = time.time() + 60 * 2
 
-   while True:
-       new_pkgs = spack.stored_packages
+    while True:
+        new_pkgs = spack.stored_packages
 
-       if len(new_pkgs) > len(pkgs) or time.time() > timeout:
-           break
+        if len(new_pkgs) > len(pkgs) or time.time() > timeout:
+            break
 
-       time.sleep(0.1)
+        time.sleep(0.1)
 
-   assert len(new_pkgs) > len(pkgs)
+    assert len(new_pkgs) > len(pkgs)
 
-   spack.stop_package_timer()
+    spack.stop_package_timer()

--- a/tests/integration/utils.py
+++ b/tests/integration/utils.py
@@ -59,6 +59,12 @@ def delete_environments_folder_from_test_repo(artifacts: Artifacts):
             artifacts, oid, "delete environments"
         )
 
+    if artifacts.recipes_root in tree:
+        treeBuilder = artifacts.repo.TreeBuilder(tree)
+        treeBuilder.remove(artifacts.recipes_root)
+        oid = treeBuilder.write()
+        commit_and_push_test_repo_changes(artifacts, oid, "delete recipes")
+
 
 def commit_and_push_test_repo_changes(
     artifacts: Artifacts, oid: pygit2.Oid, msg: str


### PR DESCRIPTION
Allows recipes to be requested and the fulfilled.

When fulfilled, environments that were waiting for a recipe to be created will be updated to include the canonical recipe name (& version) and then sent to the builder (if it's not waiting on more recipes).