### PR TITLE
Fix incorrect email being sent out of build complete/fail.

### DIFF
--- a/softpack_core/service.py
+++ b/softpack_core/service.py
@@ -144,8 +144,6 @@ class ServiceAPI(API):
 
                     files[i] = (f.filename, contents)
 
-                    break
-
                 if f.filename == artifacts.module_file:
                     newState = State.ready
 


### PR DESCRIPTION
The builder uploads the build.log on a success as well as failure, so we shouldn't break after reading the build log in case there's also a module file to be noticed (indicating a success, instead of a failure).